### PR TITLE
update minimum version to be closer to the actual HLIL compatible version

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -13,5 +13,5 @@
   },
   "version": "1.0",
   "author": "atxsinn3r",
-  "minimumbinaryninjaversion": 2000
+  "minimumbinaryninjaversion": 2096
 }


### PR DESCRIPTION
The previous minimumbinaryversion could result in the plugin being installed on versions of BinaryNinja that do not have the HLIL APIs.

Also, if you would like to have the plugin available in the plugin manager, please create a tag and release (https://binary.ninja/2019/07/04/plugin-manager-2.0.html#5-create-a-release)